### PR TITLE
(Old) ALUtils.java: Delay logged message 'building'

### DIFF
--- a/src/main/java/dev/thedocruby/resounding/openal/ALUtils.java
+++ b/src/main/java/dev/thedocruby/resounding/openal/ALUtils.java
@@ -44,8 +44,12 @@ public class ALUtils {
 		
 	}
 
+	public static boolean checkErrors(Supplier<String> messageSupplier) {
+		return checkErrors(s -> LOGGER.info(() -> s+messageSupplier.get()));
+	}
+
 	public static boolean checkErrors(String message) {
-		return checkErrors(s -> LOGGER.info(s+message));
+		return checkErrors(() -> message);
 	}
 
 	@Contract(pure = true)
@@ -76,21 +80,23 @@ public class ALUtils {
 
 	// wrapped error functions {
 	public static boolean errorApply(String   in, int   inID, String out, int outID) {
-		return errorApply(new String[]{in}, new int[]{inID}, out, outID);
+		return ALUtils.checkErrors(() -> "Error while applying "+in+"."+iniD+" to "+out+"."+outID);
 	}
 	public static boolean errorApply(String[] in, int[] inIDs, String out, int outID) {
 		if (in.length != inIDs.length) throw new IllegalStateException("differing input lengths");
-		String[] message = {};
-		for (int i = 0; i<in.length; i++) {
-			message = ArrayUtils.add(message, in[i]+"."+inIDs[i]);
-		}
-		return ALUtils.checkErrors("Error while applying "+String.join(" & ", message)+" to "+out+"."+outID);
+		return ALUtils.checkErrors(() -> {
+			StringJoiner messageJoiner = new StringJoiner(" & ", "Error while applying ", " to "+out+"."+outID);
+			for (int i = 0; i<in.length; i++) {
+				messageJoiner.add(in[i]+"."+inIDs[i]);
+			}
+			return messageJoiner.toString();
+		});
 	}
 	public static boolean errorProperty(String type, int id, String property, float value) {
-		return ALUtils.checkErrors("Error while setting "+type+"."+id+"."+property+" to "+value);
+		return ALUtils.checkErrors(() -> "Error while setting "+type+"."+id+"."+property+" to "+value);
 	}
 	public static boolean errorSet(String type, String subset, int id, float value) {
-		return ALUtils.checkErrors("Error while setting "+type+"."+subset+"."+id+" to "+value);
+		return ALUtils.checkErrors(() -> "Error while setting "+type+"."+subset+"."+id+" to "+value);
 	}
 	// }
 

--- a/src/main/java/dev/thedocruby/resounding/openal/ALUtils.java
+++ b/src/main/java/dev/thedocruby/resounding/openal/ALUtils.java
@@ -7,7 +7,9 @@ import org.lwjgl.openal.ALC10;
 
 import static dev.thedocruby.resounding.config.PrecomputedConfig.pC;
 import static dev.thedocruby.resounding.Engine.LOGGER;
+import java.util.StringJoiner;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -80,7 +82,7 @@ public class ALUtils {
 
 	// wrapped error functions {
 	public static boolean errorApply(String   in, int   inID, String out, int outID) {
-		return ALUtils.checkErrors(() -> "Error while applying "+in+"."+iniD+" to "+out+"."+outID);
+		return ALUtils.checkErrors(() -> "Error while applying "+in+"."+inID+" to "+out+"."+outID);
 	}
 	public static boolean errorApply(String[] in, int[] inIDs, String out, int outID) {
 		if (in.length != inIDs.length) throw new IllegalStateException("differing input lengths");


### PR DESCRIPTION
Move to: #105

<details>
<summary>
Original description
</summary>

> ### TLDR;
> 
> This update introduces `checkError(Supplier<String>)` for lazily built log messages.
> 
> <hr>
> 
> #### The Issue:
> 
> In the current code, messages passed to `checkError(String)` are, potentially complex and eagerly built, string. However, this approach may unnecessarily create messages that may never be used due to the way `checkError(Consumer<String>)` works.
> 
> #### The Proposed Solution:
> 
> `checkError(Supplier<String>)` tries to address the issue by providing a way to defer the message building when it's needed, saving unnecessary processing when no errors occur.
> 
> #### Alternative Approach:
> 
> As an alternative, the underlying logger's functionality can be used directly. One interpretation might discourage `checkError(String)` in favor of `checkError(Consumer<String>)` to do the logging there, though it may result in duplicated code.
> 
> <hr>
> 
> I would really welcome feedback and reviews as I don't understand why I'm so hesitant in making this pull request. (And thanks to ChatGPT for helping me make this more readable)
> 
> #### Transparency
> 
> <details>
> <summary>
> Original description.
> </summary>
> 
> > ### TLDR;
> > 
> > `checkErrors(Supplier<String>)`'s allow message strings, usually built before being sent to `checkErrors(String)`, to be made or built when needed lazily.
> > 
> > <hr>
> > 
> > `checkErrors(Consumer<String>` will only process or consume an error message if debug logging is enabled and when there is an error to work with. `checkErrors(String)` internally calls `checkErrors(Consumer<String>)` with a consumer that consumes the parameter, the error message, as a message logged by the `Engine.LOGGER`. I propose an improvement to `checkErrors(String)`, or rather an alternative is the new method `checkError(Supplier<String>) as we can provide it the how to build the message string we want, albeit if immutable data are used, and it will only perform the message building when a message is needed.
> > 
> > Alternative: expose the logger part to allow the utilization of its functionality that otherwise was simplified as a single string.
> 
> </details>
> 
> <details>
> <summary>
> ChatGPT's suggestion.
> </summary>
> 
> > ### TLDR;
> > 
> > This update introduces improvements to how errors are handled and logged in the `ALUtils` class.
> > 
> > <hr>
> > 
> > #### The Issue:
> > 
> > In the current code, error messages are logged using a fixed string format. However, this approach has some limitations, as it may log unnecessary messages or build complex error strings even when there are no errors.
> > 
> > #### The Proposed Solution:
> > 
> > To address these limitations, we are introducing a new and more flexible method called `checkError(Supplier<String>)`. This method allows us to provide a "blueprint" for building the error message only when it's needed, saving unnecessary processing when no errors occur.
> > 
> > #### What's Changed:
> > 
> > 1. We added three overloaded `checkErrors` methods:
> >    - `checkErrors(Consumer<String> callback)`: This method takes a function that can consume the error message. It will only process and log the message if debug logging is enabled and when there's an actual error to report.
> >    - `checkErrors(String message)`: This method calls the above method internally, but it now accepts a direct error message string. This is kept for backward compatibility.
> >    - `checkErrors(Supplier<String> messageSupplier)`: This method allows for lazy evaluation of the error message. It takes a supplier function that provides the error message when requested.
> > 
> > 2. We also introduced new methods for handling specific types of errors, such as `errorApply`, `errorProperty`, and `errorSet`. These methods utilize the `checkErrors` functionality for consistent error handling.
> > 
> > #### Why It Matters:
> > 
> > By using the new `checkError(Supplier<String>)` method and the improved error handling methods, we can build error messages more efficiently and avoid unnecessary overhead. Additionally, this enhancement gives developers more control over error logging and helps improve the overall code quality.
> > 
> > #### Alternative Approach:
> > 
> > As an alternative, we considered exposing the underlying logger's functionality directly, but we believe that the new `checkError` method provides a cleaner and more maintainable solution, keeping the logger implementation encapsulated.
> > 
> > We welcome feedback and reviews to ensure that these changes are beneficial and align with the project's goals.
> 
> </details>

</details>
