### PR TITLE
Memoization: exception handling

### DIFF
--- a/src/main/java/dev/thedocruby/resounding/Utils.java
+++ b/src/main/java/dev/thedocruby/resounding/Utils.java
@@ -3,6 +3,8 @@ package dev.thedocruby.resounding;
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 import com.google.gson.reflect.TypeToken;
+import dev.thedocruby.resounding.util.memoize.Memoization;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackProfile;
@@ -50,27 +52,26 @@ public class Utils {
     public static boolean[][] extendArray (final boolean[][] old, final int min) {
         return ArrayUtils.addAll(old, new boolean[Math.max(1,old.length - min)][]);
     }
+
+    /**
+     * @deprecated Replaced by {@code Memoization.withDependenciesFirstRemoveVisited}
+     *
+     * @see Memoization#withDependenciesFirstRemoveVisited
+     */
+    @Deprecated
     public static <IN,OUT> OUT memoize(HashMap<String, IN> in, HashMap<String, OUT> out, String key, BiFunction<Function<String, OUT>, IN, OUT> calculate) {
-        return memoize(in, out, key, calculate, true);
+        return Memoization.withDependenciesFirstRemoveVisited(in, out, key, calculate);
     }
 
+    /**
+     * @deprecated Replaced by {@code Memoization.withDependenciesFirstAnyways}
+     *
+     * @see Memoization#withDependenciesFirstAnyways
+     */
+    @Deprecated
     // specialized memoization for tag/material cache functionality
     public static <IN,OUT> OUT memoize(HashMap<String, IN> in, HashMap<String, OUT> out, String key, BiFunction<Function<String, OUT>, IN, OUT> calculate, boolean remove) {
-        // return cached values
-        if (out.containsKey(key))
-            return out.get(key);
-        // mark as in-progress
-        // getter == null; should be scanned for in calculate to prevent cyclic references
-        out.put(key, null);
-        OUT value = null;
-        if (in.containsKey(key))
-            value = calculate.apply(
-                x -> memoize(in, out, x, calculate, remove),
-                remove ? in.remove(key) : in.get(key));
-        out.put(key, value);
-        if (value == null)
-            LOGGER.error("{} is invalid or cyclical", key);
-        return value;
+        return Memoization.withDependenciesFirstAnyways(in, out, key, calculate, remove);
     }
 
     public static Double when(Double value, Double coefficient) {

--- a/src/main/java/dev/thedocruby/resounding/Utils.java
+++ b/src/main/java/dev/thedocruby/resounding/Utils.java
@@ -53,9 +53,8 @@ public class Utils {
     }
 
     /**
-     * @deprecated Replaced by {@code Memoization.withDependenciesFirstRemoveVisited}
-     *
      * @see Memoization#withDependenciesFirstRemoveVisited
+     * @deprecated Replaced by {@code Memoization.withDependenciesFirstRemoveVisited}
      */
     @Deprecated
     public static <IN,OUT> OUT memoize(HashMap<String, IN> in, HashMap<String, OUT> out, String key, BiFunction<Function<String, OUT>, IN, OUT> calculate) {
@@ -63,9 +62,8 @@ public class Utils {
     }
 
     /**
-     * @deprecated Replaced by {@code Memoization.withDependenciesFirstAnyways}
-     *
      * @see Memoization#withDependenciesFirstAnyways
+     * @deprecated Replaced by {@code Memoization.withDependenciesFirstAnyways}
      */
     @Deprecated
     // specialized memoization for tag/material cache functionality

--- a/src/main/java/dev/thedocruby/resounding/Utils.java
+++ b/src/main/java/dev/thedocruby/resounding/Utils.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 import com.google.gson.reflect.TypeToken;
 import dev.thedocruby.resounding.util.memoize.Memoization;
-import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackProfile;

--- a/src/main/java/dev/thedocruby/resounding/util/DoNothingSet.java
+++ b/src/main/java/dev/thedocruby/resounding/util/DoNothingSet.java
@@ -1,0 +1,53 @@
+package dev.thedocruby.resounding.util;
+
+import java.util.AbstractSet;
+import java.util.Collections;
+import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A set that does not store added elements.
+ *
+ * @param <E> the element type
+ */
+public class DoNothingSet<E> extends AbstractSet<E> {
+    /**
+     * The do-nothing set.
+     */
+    @SuppressWarnings("rawtypes")
+    public static final DoNothingSet INSTANCE =  new DoNothingSet();
+
+    /**
+     * Returns a do-nothing set.
+     *
+     * @return a do-nothing set
+     * @param <T> the element type
+     */
+    public static <T> DoNothingSet<T> getInstance() {
+        @SuppressWarnings("unchecked")
+        final var instance = (DoNothingSet<T>) INSTANCE;
+        return instance;
+    }
+
+    // NOTE: hardcode implementations only if needed
+
+    @Override
+    public boolean add(final E ignored) {
+        return true;
+    }
+
+    @Override
+    public boolean contains(final Object ignored) {
+        return false;
+    }
+
+    @Override
+    public @NotNull Iterator<E> iterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+}

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/AlreadyVisitedMemoizationException.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/AlreadyVisitedMemoizationException.java
@@ -1,0 +1,53 @@
+package dev.thedocruby.resounding.util.memoize;
+
+/**
+ * A visiting memoization visited more than what allowed. Usually visitation
+ * limits are simply once or none at all.
+ */
+public class AlreadyVisitedMemoizationException extends MemoizationException {
+    /**
+     * Constructs a new already visited memoization exception with the specified
+     * cause and a detail message.
+     *
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(Throwable)
+     *          new RuntimeException(Throwable)
+     */
+    public AlreadyVisitedMemoizationException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new already visited memoization exception with the specified
+     * detail message and cause.
+     *
+     * @param message  the detail message
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(String, Throwable)
+     *          new RuntimeException(String, Throwable)
+     */
+    public AlreadyVisitedMemoizationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new already visited memoization exception with the specified
+     * detail message.
+     *
+     * @param message  the detail message
+     * @see RuntimeException#RuntimeException(String)
+     *          new RuntimeException(String)
+     */
+    public AlreadyVisitedMemoizationException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new already visited memoization runtime exception.
+     *
+     * @see RuntimeException#RuntimeException()
+     *          new RuntimeException()
+     */
+    public AlreadyVisitedMemoizationException() {
+    }
+}

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/CyclicMemoizationException.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/CyclicMemoizationException.java
@@ -1,0 +1,52 @@
+package dev.thedocruby.resounding.util.memoize;
+
+/**
+ * Signals a cycle-related problem during memoization.
+ */
+public class CyclicMemoizationException extends MemoizationException {
+    /**
+     * Constructs a new cyclic memoization exception with the specified cause
+     * and a detail message.
+     *
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(Throwable)
+     *          new RuntimeException(Throwable)
+     */
+    public CyclicMemoizationException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new cyclic memoization exception with the specified detail
+     * message and cause.
+     *
+     * @param message  the detail message
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(String, Throwable)
+     *          new RuntimeException(String, Throwable)
+     */
+    public CyclicMemoizationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new cyclic memoization exception with the specified detail
+     * message.
+     *
+     * @param message  the detail message
+     * @see RuntimeException#RuntimeException(String)
+     *          new RuntimeException(String)
+     */
+    public CyclicMemoizationException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new cyclic memoization runtime exception.
+     *
+     * @see RuntimeException#RuntimeException()
+     *          new RuntimeException()
+     */
+    public CyclicMemoizationException() {
+    }
+}

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/InvalidMemoizationOutputException.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/InvalidMemoizationOutputException.java
@@ -2,7 +2,11 @@ package dev.thedocruby.resounding.util.memoize;
 
 /**
  * Signals that a memoization output was invalid.
+ *
+ * @see MemoizationException
+ * @deprecated Unused, prefer {@code MemoizationException}
  */
+@Deprecated(forRemoval = true)
 public class InvalidMemoizationOutputException extends MemoizationException {
     /**
      * Constructs a new invalid memoization output exception with the specified

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/InvalidMemoizationOutputException.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/InvalidMemoizationOutputException.java
@@ -1,0 +1,52 @@
+package dev.thedocruby.resounding.util.memoize;
+
+/**
+ * Signals that a memoization output was invalid.
+ */
+public class InvalidMemoizationOutputException extends MemoizationException {
+    /**
+     * Constructs a new invalid memoization output exception with the specified
+     * cause and a detail message.
+     *
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(Throwable)
+     *          new RuntimeException(Throwable)
+     */
+    public InvalidMemoizationOutputException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new invalid memoization output exception with the specified
+     * detail message and cause.
+     *
+     * @param message  the detail message
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(String, Throwable)
+     *          new RuntimeException(String, Throwable)
+     */
+    public InvalidMemoizationOutputException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new invalid memoization output exception with the specified
+     * detail message.
+     *
+     * @param message  the detail message
+     * @see RuntimeException#RuntimeException(String)
+     *          new RuntimeException(String)
+     */
+    public InvalidMemoizationOutputException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new invalid memoization output runtime exception.
+     *
+     * @see RuntimeException#RuntimeException()
+     *          new RuntimeException()
+     */
+    public InvalidMemoizationOutputException() {
+    }
+}

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
@@ -38,7 +38,7 @@ public final class Memoization {
         final @NotNull BiFunction<
             @NotNull Function<String, @NotNull OUT>,
             @NotNull IN,
-            @Nullable OUT
+            OUT
         > calculator
     ) throws MemoizationException {
         return withDependenciesFirstAnyways(inputs, outputs, key, calculator, true);

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
@@ -31,7 +31,7 @@ public final class Memoization {
      * @throws MemoizationException  if memoization was unsuccessful
      * @see #withDependenciesFirstAnyways(Map, Map, String, BiFunction, boolean)
      */
-    public static <IN, OUT>  @NotNull OUT withDependenciesFirstRemoveVisited(
+    public static <IN, OUT> @NotNull OUT withDependenciesFirstRemoveVisited(
         final @NotNull Map<String, IN> inputs,
         final @NotNull Map<String, @NotNull OUT> outputs,
         final String key,
@@ -62,7 +62,7 @@ public final class Memoization {
      * @throws MemoizationException  if memoization was unsuccessful
      * @see #withDependenciesFirst(Map, Map, String, BiFunction, boolean, boolean)
      */
-    public static <IN, OUT>  @NotNull OUT withDependenciesFirstAnyways(
+    public static <IN, OUT> @NotNull OUT withDependenciesFirstAnyways(
         final @NotNull Map<String, IN> inputs,
         final @NotNull Map<String, @NotNull OUT> outputs,
         final String key,
@@ -99,7 +99,7 @@ public final class Memoization {
      * @return the output value
      * @throws MemoizationException  if memoization was unsuccessful
      */
-    public static <IN, OUT>  @NotNull OUT withDependenciesFirst(
+    public static <IN, OUT> @NotNull OUT withDependenciesFirst(
         final @NotNull Map<String, IN> inputs,
         final @NotNull Map<String, @NotNull OUT> outputs,
         final String key,

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
@@ -214,7 +214,7 @@ public final class Memoization {
         }
 
         generatedKeys.add(key);
-        outputs.put(key, null);
+        outputs.put(key, output);
         return output;
     }
 

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
@@ -3,6 +3,9 @@ package dev.thedocruby.resounding.util.memoize;
 import dev.thedocruby.resounding.util.DoNothingSet;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -28,11 +31,15 @@ public final class Memoization {
      * @throws MemoizationException  if memoization was unsuccessful
      * @see #withDependenciesFirstAnyways(Map, Map, String, BiFunction, boolean)
      */
-    public static <IN, OUT> OUT withDependenciesFirstRemoveVisited(
-        final Map<String, IN> inputs,
-        final Map<String, OUT> outputs,
+    public static <IN, OUT>  @NotNull OUT withDependenciesFirstRemoveVisited(
+        final @NotNull Map<String, IN> inputs,
+        final @NotNull Map<String, @NotNull OUT> outputs,
         final String key,
-        final BiFunction<Function<String, OUT>, IN, OUT> calculator
+        final @NotNull BiFunction<
+            @NotNull Function<String, @NotNull OUT>,
+            @NotNull IN,
+            @Nullable OUT
+        > calculator
     ) throws MemoizationException {
         return withDependenciesFirstAnyways(inputs, outputs, key, calculator, true);
     }
@@ -55,11 +62,15 @@ public final class Memoization {
      * @throws MemoizationException  if memoization was unsuccessful
      * @see #withDependenciesFirst(Map, Map, String, BiFunction, boolean, boolean)
      */
-    public static <IN, OUT> OUT withDependenciesFirstAnyways(
-        final Map<String, IN> inputs,
-        final Map<String, OUT> outputs,
+    public static <IN, OUT>  @NotNull OUT withDependenciesFirstAnyways(
+        final @NotNull Map<String, IN> inputs,
+        final @NotNull Map<String, @NotNull OUT> outputs,
         final String key,
-        final BiFunction<Function<String, OUT>, IN, OUT> calculator,
+        final @NotNull BiFunction<
+            @NotNull Function<String, @NotNull OUT>,
+            @NotNull IN,
+            OUT
+        > calculator,
         final boolean removeVisited
     ) throws MemoizationException {
         return withDependenciesFirst(inputs, outputs, key, calculator, removeVisited, false);
@@ -88,11 +99,15 @@ public final class Memoization {
      * @return the output value
      * @throws MemoizationException  if memoization was unsuccessful
      */
-    public static <IN, OUT> OUT withDependenciesFirst(
-        final Map<String, IN> inputs,
-        final Map<String, OUT> outputs,
+    public static <IN, OUT>  @NotNull OUT withDependenciesFirst(
+        final @NotNull Map<String, IN> inputs,
+        final @NotNull Map<String, @NotNull OUT> outputs,
         final String key,
-        final BiFunction<Function<String, OUT>, IN, OUT> calculator,
+        final @NotNull BiFunction<
+            @NotNull Function<String, @NotNull OUT>,
+            @NotNull IN,
+            OUT
+        > calculator,
         final boolean removeVisited,
         final boolean noChangeOnFail
     ) throws MemoizationException {
@@ -146,14 +161,18 @@ public final class Memoization {
      * @return the output value
      * @throws MemoizationException  if memoization was unsuccessful
      */
-    private static <IN, OUT> OUT withDependenciesFirstInternal(
-        final Map<String, IN> inputs,
-        final Map<String, OUT> outputs,
-        final Set<String> visitedKeys,
-        final Set<String> generatedKeys,
-        final ObjectLinkedOpenHashSet<String> keyPath,
+    private static <IN, OUT> @NotNull OUT withDependenciesFirstInternal(
+        final @NotNull Map<String, IN> inputs,
+        final @NotNull Map<String, @NotNull OUT> outputs,
+        final @NotNull Set<String> visitedKeys,
+        final @NotNull Set<String> generatedKeys,
+        final @NotNull ObjectLinkedOpenHashSet<String> keyPath,
         final String key,
-        final BiFunction<Function<String, OUT>, IN, OUT> calculator
+        final @NotNull BiFunction<
+            @NotNull Function<String, @NotNull OUT>,
+            @NotNull IN,
+            OUT
+        > calculator
     ) throws MemoizationException {
         if (!visitedKeys.add(key)) {
             throw new AlreadyVisitedMemoizationException("Already visited key '" + key + "'");
@@ -207,8 +226,8 @@ public final class Memoization {
         }
 
         if (output == null) {
-            throw new InvalidMemoizationOutputException(
-                "The memoization calculation resulted with null",
+            throw new MemoizationException(
+                "Memoization calculation resulted with null for key'" + key + "'",
                 new NullPointerException("The calculator function evaluated to null")
             );
         }

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/Memoization.java
@@ -1,0 +1,226 @@
+package dev.thedocruby.resounding.util.memoize;
+
+import dev.thedocruby.resounding.util.DoNothingSet;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Utility class for memoization.
+ */
+public final class Memoization {
+    /**
+     * Calculated an output and its dependencies for a given key. Visited inputs
+     * during calculation will be removed, which is equivalent to calling {@code
+     *     withDependenciesFirstAnyways(inputs, outputs, key, calculator, true)
+     * }
+     *
+     * @param <IN>  the input type
+     * @param <OUT>  the output type
+     * @param inputs  the inputs (for read)
+     * @param outputs  the outputs (for read and write)
+     * @param key  the key to retrieve the output of
+     * @param calculator  the output calculator
+     * @return the output value
+     * @throws MemoizationException  if memoization was unsuccessful
+     * @see #withDependenciesFirstAnyways(Map, Map, String, BiFunction, boolean)
+     */
+    public static <IN, OUT> OUT withDependenciesFirstRemoveVisited(
+        final Map<String, IN> inputs,
+        final Map<String, OUT> outputs,
+        final String key,
+        final BiFunction<Function<String, OUT>, IN, OUT> calculator
+    ) throws MemoizationException {
+        return withDependenciesFirstAnyways(inputs, outputs, key, calculator, true);
+    }
+
+    /**
+     * Calculated an output and its dependencies for a given key. Any changes to
+     * {@code inputs} and {@code outputs} are kept on failure, which is
+     * equivalent to calling {@code
+     *     withDependenciesFirst(inputs, outputs, key, calculator, removeVisited, true)
+     * }.
+     *
+     * @param <IN>  the input type
+     * @param <OUT>  the output type
+     * @param inputs  the inputs (for read)
+     * @param outputs  the outputs (for read and write)
+     * @param key  the key to retrieve the output of
+     * @param calculator  the output calculator
+     * @param removeVisited  should the visited inputs be removed
+     * @return the output value
+     * @throws MemoizationException  if memoization was unsuccessful
+     * @see #withDependenciesFirst(Map, Map, String, BiFunction, boolean, boolean)
+     */
+    public static <IN, OUT> OUT withDependenciesFirstAnyways(
+        final Map<String, IN> inputs,
+        final Map<String, OUT> outputs,
+        final String key,
+        final BiFunction<Function<String, OUT>, IN, OUT> calculator,
+        final boolean removeVisited
+    ) throws MemoizationException {
+        return withDependenciesFirst(inputs, outputs, key, calculator, removeVisited, false);
+    }
+
+    /**
+     * Calculated an output and its dependencies for a given key.
+     * <ul>
+     * <li>If the parameter {@code removeVisited} is set to {@code false}, then
+     * the parameter {@code inputs} will be unchanged; otherwise visited inputs
+     * are removed.
+     * <li>If the parameter {@code noChangeOnFail} is set to {@code true}, then
+     * both parameters {@code inputs} and {@code outputs} will be unchanged;
+     * otherwise visited inputs are removed and newly generated outputs are
+     * retained on failure.
+     * </ul>
+     *
+     * @param <IN>  the input type
+     * @param <OUT>  the output type
+     * @param inputs  the inputs (for read)
+     * @param outputs  the outputs (for read and write)
+     * @param key  the key to retrieve the output of
+     * @param calculator  the output calculator
+     * @param removeVisited  should the visited inputs be removed
+     * @param noChangeOnFail  should the input and outputs be unchanged on fail
+     * @return the output value
+     * @throws MemoizationException  if memoization was unsuccessful
+     */
+    public static <IN, OUT> OUT withDependenciesFirst(
+        final Map<String, IN> inputs,
+        final Map<String, OUT> outputs,
+        final String key,
+        final BiFunction<Function<String, OUT>, IN, OUT> calculator,
+        final boolean removeVisited,
+        final boolean noChangeOnFail
+    ) throws MemoizationException {
+        final Set<String> visitedKeys = removeVisited
+            ? new ObjectOpenHashSet<>()
+            : DoNothingSet.getInstance();
+        final Set<String> generatedKeys = noChangeOnFail
+            ? new ObjectOpenHashSet<>()
+            : DoNothingSet.getInstance();
+        final var keyPath = new ObjectLinkedOpenHashSet<String>();
+
+        try {
+            final var output = withDependenciesFirstInternal(
+                inputs,
+                outputs,
+                visitedKeys,
+                generatedKeys,
+                keyPath,
+                key,
+                calculator
+            );
+
+            // NOTE: only remove from inputs if no exceptions are caught
+            inputs.keySet().removeAll(visitedKeys);
+
+            return output;
+        } catch (final RuntimeException caught) {
+            if (!noChangeOnFail) {
+                inputs.keySet().removeAll(visitedKeys);
+            }
+
+            // NOTE: removes generated outputs on exceptions
+            outputs.keySet().removeAll(generatedKeys);
+
+            throw caught;
+        }
+    }
+
+    /**
+     * Calculated an output and its dependencies for a given key.
+     *
+     * @param <IN>  the input type
+     * @param <OUT>  the output type
+     * @param inputs  the inputs (for read)
+     * @param outputs  the outputs (for read and write)
+     * @param visitedKeys  the visited keys (effectively removed input keys)
+     * @param generatedKeys  the generated keys (outputs to remove on fail)
+     * @param keyPath  the current key path (used to detect cyclic dependencies)
+     * @param key  the key to retrieve the output of
+     * @param calculator  the output calculator
+     * @return the output value
+     * @throws MemoizationException  if memoization was unsuccessful
+     */
+    private static <IN, OUT> OUT withDependenciesFirstInternal(
+        final Map<String, IN> inputs,
+        final Map<String, OUT> outputs,
+        final Set<String> visitedKeys,
+        final Set<String> generatedKeys,
+        final ObjectLinkedOpenHashSet<String> keyPath,
+        final String key,
+        final BiFunction<Function<String, OUT>, IN, OUT> calculator
+    ) throws MemoizationException {
+        if (!visitedKeys.add(key)) {
+            throw new AlreadyVisitedMemoizationException("Already visited key '" + key + "'");
+        }
+        if (keyPath.contains(key)) {
+            throw new CyclicMemoizationException(
+                "Keys entered a cycle: " + String.join(" -> ", keyPath) + " -> " + key
+            );
+        }
+
+        {
+            final var output = outputs.get(key);
+            if (output != null /* || outputs.containsKey(key) */) {
+                return output;
+            }
+        }
+
+        keyPath.add(key);
+
+        final var input = inputs.get(key);
+        if (input == null /* && !inputs.containsKey(key) */) {
+            throw new MissingInputMemoizationException("Missing input value for key '" + key + "'");
+        }
+
+        final OUT output;
+        try {
+            // NOTE: only catch if the calculation fails
+            output = calculator.apply(
+                dependency -> withDependenciesFirstInternal(
+                    inputs,
+                    outputs,
+                    visitedKeys,
+                    generatedKeys,
+                    keyPath,
+                    dependency,
+                    calculator
+                ),
+                input
+            );
+        } catch (final CyclicMemoizationException special) {
+            // NOTE: special case as it SHOULD announce involved keys
+            throw special;
+        } catch (final RuntimeException cause) {
+            // NOTE: intentionally nests MemoizationException(s)
+            throw new MemoizationException(
+                "Exception caught while calculating key '" + key + "'",
+                cause
+            );
+        } finally {
+            keyPath.removeLast();
+        }
+
+        if (output == null) {
+            throw new InvalidMemoizationOutputException(
+                "The memoization calculation resulted with null",
+                new NullPointerException("The calculator function evaluated to null")
+            );
+        }
+
+        generatedKeys.add(key);
+        outputs.put(key, null);
+        return output;
+    }
+
+    /**
+     * @deprecated Utility classes need no instantiation.
+     */
+    @Deprecated
+    private Memoization() {}
+}

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/MemoizationException.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/MemoizationException.java
@@ -1,0 +1,51 @@
+package dev.thedocruby.resounding.util.memoize;
+
+/**
+ * Signals a problem occurred during memoization.
+ */
+public class MemoizationException extends RuntimeException {
+    /**
+     * Constructs a new memoization exception with the specified cause and a
+     * detail message.
+     *
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(Throwable)
+     *          new RuntimeException(Throwable)
+     */
+    public MemoizationException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new memoization exception with the specified detail message
+     * and cause.
+     *
+     * @param message  the detail message
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(String, Throwable)
+     *          new RuntimeException(String, Throwable)
+     */
+    public MemoizationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new memoization exception with the specified detail message.
+     *
+     * @param message  the detail message
+     * @see RuntimeException#RuntimeException(String)
+     *          new RuntimeException(String)
+     */
+    public MemoizationException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new memoization runtime exception.
+     *
+     * @see RuntimeException#RuntimeException()
+     *          new RuntimeException()
+     */
+    public MemoizationException() {
+    }
+}

--- a/src/main/java/dev/thedocruby/resounding/util/memoize/MissingInputMemoizationException.java
+++ b/src/main/java/dev/thedocruby/resounding/util/memoize/MissingInputMemoizationException.java
@@ -1,0 +1,52 @@
+package dev.thedocruby.resounding.util.memoize;
+
+/**
+ * An input required during memoization is missing or unassigned.
+ */
+public class MissingInputMemoizationException extends MemoizationException {
+    /**
+     * Constructs a new missing input memoization exception with the specified
+     * cause and a detail message.
+     *
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(Throwable)
+     *          new RuntimeException(Throwable)
+     */
+    public MissingInputMemoizationException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new missing input memoization exception with the specified
+     * detail message and cause.
+     *
+     * @param message  the detail message
+     * @param cause  the cause
+     * @see RuntimeException#RuntimeException(String, Throwable)
+     *          new RuntimeException(String, Throwable)
+     */
+    public MissingInputMemoizationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new missing input memoization exception with the specified
+     * detail message.
+     *
+     * @param message  the detail message
+     * @see RuntimeException#RuntimeException(String)
+     *          new RuntimeException(String)
+     */
+    public MissingInputMemoizationException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new missing input memoization runtime exception.
+     *
+     * @see RuntimeException#RuntimeException()
+     *          new RuntimeException()
+     */
+    public MissingInputMemoizationException() {
+    }
+}


### PR DESCRIPTION
What changed?
 - Utils.memoize is deprecated and replaced by methods in the class named Memoization (also have javadoc); their implementation are replaced to call to the new methods
 - added ~~five~~ four runtime exception classes to represent a type of memoization exception
   - the base class also acts as a wrapper exception
 - both input and output maps can be unchanged on a failure with a single flag
 - null input and output are not allowed (unless changed in code)

What didn't change (yet)?
 - callers of then Utils.memoize still use them and neither do have proper exception handling

I might have missed something, but hopefully this is all the main points.